### PR TITLE
Update 'deface' dependency version

### DIFF
--- a/solidus_editor.gemspec
+++ b/solidus_editor.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'ckeditor',      '~> 4.1'
-  s.add_dependency 'deface',        '~> 1.0.2'
+  s.add_dependency 'deface',        '>= 1.3.1'
   s.add_dependency 'solidus_backend', ['>= 1.0', '< 3']
   s.add_dependency 'tinymce-rails', '~> 4.2.5'
 


### PR DESCRIPTION
Ref: https://github.com/sparklemotion/nokogiri/issues/1615

Updated 'deface' gem to update 'nokogiri' dependency gem after the vulnerability 
checks with 'audit':
Nokogiri gem contains several vulnerabilities in libxml2 and libxslt.